### PR TITLE
Use manylinux2010 instead of manylinux1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,10 +88,6 @@ matrix:
     - os: osx
       language: generic
       env:
-        - MB_PYTHON_VERSION=3.4
-    - os: osx
-      language: generic
-      env:
         - MB_PYTHON_VERSION=3.5
     - os: osx
       language: generic

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
 export LIBOSMIUM_PREFIX=/io/libosmium
+export MB_ML_VER=2010
+


### PR DESCRIPTION
Use manylinux2010 wheels.

Update multibuild to fix broken builds after pip 20 was released.

Outstanding issue: building wheel for python2.7 for macOS.

Closes: #4 