### PR TITLE
Fix travis builds and warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,22 +18,16 @@ env:
         # manylinux version to build (1, 2010 or 2014)
         - MB_ML_VER=2010
 
-language: python
-# The travis Python version is unrelated to the version we build and test
-# with.  This is set with the MB_PYTHON_VERSION variable.
-python: 3.5
-sudo: required
-dist: trusty
+language: generic
+dist: xenial
+os: linux
 services: docker
 
 branches:
   except:
     - /^untagged-.*/
 
-matrix:
-  exclude:
-    # Exclude the default Python 3.5 build
-    - python: 3.5
+jobs:
   include:
     # Manylinux1
     - os: linux
@@ -55,15 +49,6 @@ matrix:
         - MB_PYTHON_VERSION=2.7
         - PLAT=i686
         - UNICODE_WIDTH=16
-        - MB_ML_VER=1
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - MB_ML_VER=1
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - PLAT=i686
         - MB_ML_VER=1
     - os: linux
       env:
@@ -117,13 +102,6 @@ matrix:
         - MB_PYTHON_VERSION=2.7
         - PLAT=i686
         - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - PLAT=i686
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
@@ -187,9 +165,9 @@ script:
 
 deploy:
   provider: releases
-  skip_cleanup: true
+  cleanup: false
   file: "wheelhouse/*whl"
   file_glob: true
-  api_key: ${GITHUB_API_KEY}
+  token: ${GITHUB_API_KEY}
   on:
     branch: master


### PR DESCRIPTION
- remove exclude section as it prevented jobs creation
- change keys in deploy to be compatibile with dpl2
- move from trusty to xenial (we are building anyway inside docker in CentOS)
- remove 3.4 builds as its not longer supported