### PR TITLE
Change testing strategy. No idea why it fixes missing libexpat

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -81,5 +81,5 @@ function run_tests {
     fi
     python --version
     cd ../pyosmium/test
-    python -m nose
+    python -m nose test*py
 }


### PR DESCRIPTION
Fixes:
`ImportError: libexpat.so.0: cannot open shared object file: No such file or directory`

On x86_64 manylinux1 test runs